### PR TITLE
chore: remove version

### DIFF
--- a/lintrules-gradle-publish/bintray.gradle
+++ b/lintrules-gradle-publish/bintray.gradle
@@ -5,7 +5,7 @@ publish {
     repoName = 'LintRules'
     groupId = 'com.chesire'
     artifactId = 'lint-gradle'
-    publishVersion = '0.0.1'
+    publishVersion = '0.0.0'
     desc = 'Provides extra lint rules based around Gradle to the project.'
     website = 'https://github.com/Chesire/LintRules'
 }


### PR DESCRIPTION
The version should be passed in through the publish command, leave it at a default of 0.0.0