### PR TITLE
fix: xml lintrules cannot be registered

### DIFF
--- a/lintrules-xml/build.gradle
+++ b/lintrules-xml/build.gradle
@@ -13,6 +13,6 @@ dependencies {
 
 jar {
     manifest {
-        attributes('Lint-Registry-v2': 'com.chesire.lintrules.gradle.XmlLintRegistry')
+        attributes('Lint-Registry-v2': 'com.chesire.lintrules.xml.XmlLintRegistry')
     }
 }


### PR DESCRIPTION
The package id used for the lintrules-xml package being used was incorrectly, this wasn't picked up
in unit tests so more through testing was required. In the future some way to automate testing on
this would be useful.