### PR TITLE
fix: lexicographic order invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+## Version 1.1.2
+_19-11-14_
+
+* fix: lexicographic ordering doesn't properly check for :
+  * For users who have muliple repositories then the Lexicographic ordering gets confused, as it will see that `:` is higher than `.`, so it would allow items such as `com.chesire:lifecyklelog` to come after `com.chesire.lintrules:lint-gradle`. Made it replace instances of `:` with a `.` and then do a straight compare, which should produce a valid result.
+
 ## Version 1.1.1
 _19-11-12_
 

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/DependencyDetector.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/DependencyDetector.kt
@@ -63,7 +63,14 @@ class DependencyDetector : Detector(), GradleScanner {
         dependencyItems
             .lastOrNull()
             ?.onlyIf({
-                first == property && second.compareTo(dependency, false) > 0
+                if (first != property) {
+                    return@onlyIf false
+                }
+
+                val firstString = dependency.replace(':', '.')
+                val seconString = second.replace(':', '.')
+
+                seconString.compareTo(firstString, false) > 0
             }, {
                 context.report(
                     LexicographicDependencies.issue,

--- a/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/DependencyDetectorTests.kt
+++ b/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/DependencyDetectorTests.kt
@@ -379,4 +379,41 @@ dependencies {
                 |0 errors, 1 warnings""".trimMargin()
             )
     }
+
+    @Test
+    fun `lexicographicOrder should be an issue with invalid lexicographic order same owner`() {
+        TestLintTask
+            .lint()
+            .allowMissingSdk()
+            .files(
+                TestFiles.gradle(
+                    """
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
+    implementation 'com.chesire.lintrules:lint-gradle:1.1.1'
+    implementation 'com.chesire.lintrules:lint-xml:1.1.1'
+    implementation 'com.chesire:lifecyklelog:2.1.0'
+    
+    testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
+    testImplementation 'junit:junit:4.12'
+    
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    
+    lintChecks project(":lintrules")
+}
+                """.trimIndent()
+                ).indented()
+            )
+            .issues(LexicographicDependencies.issue)
+            .run()
+            .expect(
+                """
+                |build.gradle:6: Warning: Dependencies should be listed in lexicographic order. [LexicographicDependencies]
+                |    implementation 'com.chesire:lifecyklelog:2.1.0'
+                |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                |0 errors, 1 warnings""".trimMargin()
+            )
+    }
 }


### PR DESCRIPTION
For users who have multiple repositories then the Lexicographic ordering gets confused, as it will
see that `:` is higher than `.`, so it would allow items such as `com.chesire:lifecyklelog` to
come after `com.chesire.lintrules:lint-gradle`. Made it replace instances of `:` with a `.` and
then do a straight compare, which should produce a valid result