### PR TITLE
chore: update bundler to 2.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       ox (~> 2.0)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
-    faraday (0.17.0)
+    faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.0.0)
       faraday (~> 0.8)
@@ -43,7 +43,7 @@ GEM
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    ox (2.11.0)
+    ox (2.12.0)
     public_suffix (4.0.1)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
@@ -60,4 +60,4 @@ DEPENDENCIES
   danger-checkstyle_format
 
 BUNDLED WITH
-   2.0.1
+   2.1.2


### PR DESCRIPTION
Update bundler along with some of the danger dependencies