### PR TITLE
fix: duplicate dependency false flag

### DIFF
--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/Dependency.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/Dependency.kt
@@ -1,0 +1,21 @@
+package com.chesire.lintrules.gradle
+
+/**
+ * Represents a single item within the 'dependencies' section of a Gradle file.
+ */
+data class Dependency(
+    /**
+     * Compile type.
+     *
+     * Ex: implementation, androidTestImplementation.
+     */
+    val type: String,
+    /**
+     * Name of the dependency.
+     */
+    val name: String,
+    /**
+     * Version of the dependency.
+     */
+    val version: String
+)

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/DependencyParser.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/DependencyParser.kt
@@ -1,0 +1,28 @@
+package com.chesire.lintrules.gradle
+
+/**
+ * Object to aid with parsing out dependencies into [Dependency] objects.
+ */
+object DependencyParser {
+    /**
+     * Parses [value] into a [Dependency] object, takes the compile type [type] to aid with
+     * creation of the object,
+     */
+    fun parseDependency(type: String, value: String): Dependency? {
+        val encasingChar = getEncasingChar(value) ?: return null
+        val dependencyItem = value.substring(
+            value.indexOf(encasingChar),
+            value.lastIndexOf(encasingChar)
+        )
+        val dependencyName = dependencyItem.substring(0, dependencyItem.lastIndexOf(':'))
+        val dependencyVersion = dependencyItem.substring(dependencyItem.lastIndexOf(':') + 1)
+
+        return Dependency(type, dependencyName, dependencyVersion)
+    }
+
+    private fun getEncasingChar(value: String): Char? = when {
+        value.contains("\"") -> '\"'
+        value.contains("\'") -> '\''
+        else -> null
+    }
+}

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/DependencyParser.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/DependencyParser.kt
@@ -6,7 +6,7 @@ package com.chesire.lintrules.gradle
 object DependencyParser {
     /**
      * Parses [value] into a [Dependency] object, takes the compile type [type] to aid with
-     * creation of the object,
+     * creation of the object.
      */
     fun parseDependency(type: String, value: String): Dependency? {
         val encasingChar = getEncasingChar(value) ?: return null

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/DependencyParser.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/DependencyParser.kt
@@ -11,10 +11,10 @@ object DependencyParser {
     fun parseDependency(type: String, value: String): Dependency? {
         val encasingChar = getEncasingChar(value) ?: return null
         val dependencyItem = value.substring(
-            value.indexOf(encasingChar),
+            value.indexOf(encasingChar) + 1,
             value.lastIndexOf(encasingChar)
         )
-        val dependencyName = dependencyItem.substring(0, dependencyItem.lastIndexOf(':'))
+        val dependencyName = getDependencyName(dependencyItem)
         val dependencyVersion = dependencyItem.substring(dependencyItem.lastIndexOf(':') + 1)
 
         return Dependency(type, dependencyName, dependencyVersion)
@@ -25,4 +25,10 @@ object DependencyParser {
         value.contains("\'") -> '\''
         else -> null
     }
+
+    private fun getDependencyName(value: String) =
+        value
+            .substring(0, value.lastIndexOf(':'))
+            .takeIf { it.isNotEmpty() }
+            ?: value
 }

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetector.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetector.kt
@@ -3,6 +3,8 @@ package com.chesire.lintrules.gradle.detectors
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.GradleContext
 import com.android.tools.lint.detector.api.GradleScanner
+import com.chesire.lintrules.gradle.Dependency
+import com.chesire.lintrules.gradle.DependencyParser
 import com.chesire.lintrules.gradle.issues.DuplicateDependency
 
 /**
@@ -28,33 +30,18 @@ class DuplicateDependencyDetector : Detector(), GradleScanner {
         if (parent != PARENT_TAG) {
             return
         }
-        parseDependency(value)?.let { dependency ->
-            reportIfDuplicate(context, property, dependency, valueCookie)
-            dependencyItems.add(property to dependency)
+        DependencyParser.parseDependency(property, value)?.let { dependency ->
+            reportIfDuplicate(context, dependency, valueCookie)
+            dependencyItems.add(dependency.type to dependency.name)
         }
-    }
-
-    private fun parseDependency(value: String): String? {
-        val encasingCharacter = when {
-            value.contains("\"") -> "\""
-            value.contains("\'") -> "\'"
-            else -> return null
-        }
-
-        // could expand to trim form the last index of `:`, and if it is then empty, ignore that trim
-        return value.substring(
-            value.indexOf(encasingCharacter),
-            value.lastIndexOf(encasingCharacter)
-        )
     }
 
     private fun reportIfDuplicate(
         context: GradleContext,
-        property: String,
-        dependency: String,
+        dependency: Dependency,
         valueCookie: Any
     ) {
-        if (dependencyItems.any { it.second == dependency && it.first == property }) {
+        if (dependencyItems.any { it.first == dependency.type && it.second == dependency.name }) {
             context.report(
                 DuplicateDependency.issue,
                 context.getLocation(valueCookie),

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetector.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetector.kt
@@ -1,0 +1,65 @@
+package com.chesire.lintrules.gradle.detectors
+
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.GradleContext
+import com.android.tools.lint.detector.api.GradleScanner
+import com.chesire.lintrules.gradle.issues.DuplicateDependency
+
+/**
+ * Detector used to find issues with the dependencies within Gradle.
+ */
+class DuplicateDependencyDetector : Detector(), GradleScanner {
+    companion object {
+        private const val PARENT_TAG = "dependencies"
+    }
+
+    private val dependencyItems = mutableListOf<Pair<String, String>>()
+
+    override fun checkDslPropertyAssignment(
+        context: GradleContext,
+        property: String,
+        value: String,
+        parent: String,
+        parentParent: String?,
+        propertyCookie: Any,
+        valueCookie: Any,
+        statementCookie: Any
+    ) {
+        if (parent != PARENT_TAG) {
+            return
+        }
+        parseDependency(value)?.let { dependency ->
+            reportIfDuplicate(context, property, dependency, valueCookie)
+            dependencyItems.add(property to dependency)
+        }
+    }
+
+    private fun parseDependency(value: String): String? {
+        val encasingCharacter = when {
+            value.contains("\"") -> "\""
+            value.contains("\'") -> "\'"
+            else -> return null
+        }
+
+        // could expand to trim form the last index of `:`, and if it is then empty, ignore that trim
+        return value.substring(
+            value.indexOf(encasingCharacter),
+            value.lastIndexOf(encasingCharacter)
+        )
+    }
+
+    private fun reportIfDuplicate(
+        context: GradleContext,
+        property: String,
+        dependency: String,
+        valueCookie: Any
+    ) {
+        if (dependencyItems.any { it.second == dependency && it.first == property }) {
+            context.report(
+                DuplicateDependency.issue,
+                context.getLocation(valueCookie),
+                DuplicateDependency.message
+            )
+        }
+    }
+}

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetector.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetector.kt
@@ -3,14 +3,13 @@ package com.chesire.lintrules.gradle.detectors
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.GradleContext
 import com.android.tools.lint.detector.api.GradleScanner
-import com.chesire.lintrules.gradle.issues.DuplicateDependency
 import com.chesire.lintrules.gradle.issues.LexicographicDependencies
 import org.jetbrains.kotlin.backend.common.onlyIf
 
 /**
  * Detector used to find issues with the dependencies within Gradle.
  */
-class DependencyDetector : Detector(), GradleScanner {
+class LexicographicDependenciesDetector : Detector(), GradleScanner {
     companion object {
         private const val PARENT_TAG = "dependencies"
     }
@@ -29,7 +28,6 @@ class DependencyDetector : Detector(), GradleScanner {
     ) {
         if (parent == PARENT_TAG && isValidItem(value)) {
             val dependency = value.substringBeforeLast(':').trim('"')
-            reportIfDuplicate(context, property, dependency, valueCookie)
             reportIfNotLexicographicOrder(context, property, dependency, valueCookie)
             dependencyItems.add(property to dependency)
         }
@@ -38,21 +36,6 @@ class DependencyDetector : Detector(), GradleScanner {
     // Certain items should not be included when checking
     private fun isValidItem(value: String) =
         !(value.contains("org.jetbrains.kotlin:kotlin-stdlib") || value.contains("fileTree"))
-
-    private fun reportIfDuplicate(
-        context: GradleContext,
-        property: String,
-        dependency: String,
-        valueCookie: Any
-    ) {
-        if (dependencyItems.any { it.second == dependency && it.first == property }) {
-            context.report(
-                DuplicateDependency.issue,
-                context.getLocation(valueCookie),
-                DuplicateDependency.message
-            )
-        }
-    }
 
     private fun reportIfNotLexicographicOrder(
         context: GradleContext,

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/issues/DuplicateDependency.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/issues/DuplicateDependency.kt
@@ -5,7 +5,7 @@ import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
-import com.chesire.lintrules.gradle.detectors.DependencyDetector
+import com.chesire.lintrules.gradle.detectors.DuplicateDependencyDetector
 
 /**
  * Issue for when duplicate dependencies are added to Gradle.
@@ -24,7 +24,7 @@ object DuplicateDependency {
         Category.CORRECTNESS,
         3,
         Severity.WARNING,
-        Implementation(DependencyDetector::class.java, Scope.GRADLE_SCOPE)
+        Implementation(DuplicateDependencyDetector::class.java, Scope.GRADLE_SCOPE)
     )
 
     /**

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/issues/LexicographicDependencies.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/issues/LexicographicDependencies.kt
@@ -5,7 +5,7 @@ import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
-import com.chesire.lintrules.gradle.detectors.DependencyDetector
+import com.chesire.lintrules.gradle.detectors.LexicographicDependenciesDetector
 
 /**
  * Issue for when the dependencies are not listed in lexicographic order.
@@ -21,7 +21,7 @@ object LexicographicDependencies {
         Category.CORRECTNESS,
         1,
         Severity.WARNING,
-        Implementation(DependencyDetector::class.java, Scope.GRADLE_SCOPE)
+        Implementation(LexicographicDependenciesDetector::class.java, Scope.GRADLE_SCOPE)
     )
 
     /**

--- a/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetectorTests.kt
+++ b/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetectorTests.kt
@@ -2,12 +2,12 @@ package com.chesire.lintrules.gradle.detectors
 
 import com.android.tools.lint.checks.infrastructure.TestFiles
 import com.android.tools.lint.checks.infrastructure.TestLintTask
-import com.chesire.lintrules.gradle.issues.LexicographicDependencies
+import com.chesire.lintrules.gradle.issues.DuplicateDependency
 import org.junit.Test
 
-class DependencyDetectorTests {
+class DuplicateDependencyDetectorTests {
     @Test
-    fun `lexicographicOrder should be no issue with valid Gradle file`() {
+    fun `duplicateDependency should be no issue with valid Gradle file`() {
         TestLintTask
             .lint()
             .allowMissingSdk()
@@ -45,21 +45,21 @@ dependencies {
     testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
     testImplementation 'junit:junit:4.12'
     
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     
     lintChecks project(":lintrules")
 }
                 """.trimIndent()
                 ).indented()
             )
-            .issues(LexicographicDependencies.issue)
+            .issues(DuplicateDependency.issue)
             .run()
             .expectClean()
     }
 
     @Test
-    fun `lexicographicOrder should be no issue with short valid Gradle file`() {
+    fun `duplicateDependency should be no issue with short valid Gradle file`() {
         TestLintTask
             .lint()
             .allowMissingSdk()
@@ -75,21 +75,21 @@ dependencies {
     testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
     testImplementation 'junit:junit:4.12'
     
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     
     lintChecks project(":lintrules")
 }
                 """.trimIndent()
                 ).indented()
             )
-            .issues(LexicographicDependencies.issue)
+            .issues(DuplicateDependency.issue)
             .run()
             .expectClean()
     }
 
     @Test
-    fun `lexicographicOrder should be no issue with wrong order between different implementation type`() {
+    fun `duplicateDependency should be no issue with same entry with different implementation type`() {
         TestLintTask
             .lint()
             .allowMissingSdk()
@@ -101,26 +101,26 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'z.zandroid.ztools.zlint:lint-tests:26.5.1'
     
+    testImplementation 'androidx.core:core-ktx:1.1.0'
     testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
     testImplementation 'junit:junit:4.12'
     
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     
     lintChecks project(":lintrules")
 }
                 """.trimIndent()
                 ).indented()
             )
-            .issues(LexicographicDependencies.issue)
+            .issues(DuplicateDependency.issue)
             .run()
             .expectClean()
     }
 
     @Test
-    fun `lexicographicOrder should be an issue with invalid lexicographic order`() {
+    fun `duplicateDependency should be an issue when duplicate entry`() {
         TestLintTask
             .lint()
             .allowMissingSdk()
@@ -130,33 +130,34 @@ dependencies {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
-    implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core-ktx:1.1.0'
+    implementation 'androidx.core:core-ktx:1.1.0'
     
     testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
     testImplementation 'junit:junit:4.12'
     
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     
     lintChecks project(":lintrules")
 }
                 """.trimIndent()
                 ).indented()
             )
-            .issues(LexicographicDependencies.issue)
+            .issues(DuplicateDependency.issue)
             .run()
             .expect(
                 """
-                |build.gradle:5: Warning: Dependencies should be listed in lexicographic order. [LexicographicDependencies]
-                |    implementation 'androidx.appcompat:appcompat:1.1.0'
-                |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                |build.gradle:6: Warning: Dependencies should only be added to a given module once. [DuplicateDependency]
+                |    implementation 'androidx.core:core-ktx:1.1.0'
+                |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 |0 errors, 1 warnings""".trimMargin()
             )
     }
 
     @Test
-    fun `lexicographicOrder should be an issue with invalid lexicographic order same owner`() {
+    fun `duplicateDependency should be an issue when duplicate entry with different version`() {
         TestLintTask
             .lint()
             .allowMissingSdk()
@@ -166,28 +167,65 @@ dependencies {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
-    implementation 'com.chesire.lintrules:lint-gradle:1.1.1'
-    implementation 'com.chesire.lintrules:lint-xml:1.1.1'
-    implementation 'com.chesire:lifecyklelog:2.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core-ktx:1.1.0'
+    implementation 'androidx.core:core-ktx:1.5.0'
     
     testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
     testImplementation 'junit:junit:4.12'
     
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     
     lintChecks project(":lintrules")
 }
                 """.trimIndent()
                 ).indented()
             )
-            .issues(LexicographicDependencies.issue)
+            .issues(DuplicateDependency.issue)
             .run()
             .expect(
                 """
-                |build.gradle:6: Warning: Dependencies should be listed in lexicographic order. [LexicographicDependencies]
-                |    implementation 'com.chesire:lifecyklelog:2.1.0'
-                |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                |build.gradle:6: Warning: Dependencies should only be added to a given module once. [DuplicateDependency]
+                |    implementation 'androidx.core:core-ktx:1.5.0'
+                |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                |0 errors, 1 warnings""".trimMargin()
+            )
+    }
+
+    @Test
+    fun `duplicateDependency should be an issue when duplicate entry at different location`() {
+        TestLintTask
+            .lint()
+            .allowMissingSdk()
+            .files(
+                TestFiles.gradle(
+                    """
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core-ktx:1.1.0'
+    
+    testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
+    testImplementation 'junit:junit:4.12'
+    
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    implementation 'androidx.core:core-ktx:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    
+    lintChecks project(":lintrules")
+}
+                """.trimIndent()
+                ).indented()
+            )
+            .issues(DuplicateDependency.issue)
+            .run()
+            .expect(
+                """
+                |build.gradle:11: Warning: Dependencies should only be added to a given module once. [DuplicateDependency]
+                |    implementation 'androidx.core:core-ktx:1.1.0'
+                |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 |0 errors, 1 warnings""".trimMargin()
             )
     }

--- a/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetectorTests.kt
+++ b/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetectorTests.kt
@@ -5,7 +5,7 @@ import com.android.tools.lint.checks.infrastructure.TestLintTask
 import com.chesire.lintrules.gradle.issues.LexicographicDependencies
 import org.junit.Test
 
-class DependencyDetectorTests {
+class LexicographicDependenciesDetectorTests {
     @Test
     fun `lexicographicOrder should be no issue with valid Gradle file`() {
         TestLintTask


### PR DESCRIPTION
When having multiple dependencies of type "project" (example below), they would all be flagged as duplicate of the first one, this required a bit of a refactor to how was handling duplicate dependencies. Took this opportunity to split up the dependencies into different issue detectors and implement a generic parser to get all the details into a single model.

```
implementation project(path: ':core')
implementation project(path: ':database')
implementation project(path: ':server')
```