### PR TITLE
refactor: the getting for api in the issue registry is not required

### DIFF
--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/GradleLintRegistry.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/GradleLintRegistry.kt
@@ -16,6 +16,5 @@ class GradleLintRegistry : IssueRegistry() {
             LexicographicDependencies.issue
         )
 
-    override val api: Int
-        get() = CURRENT_API
+    override val api = CURRENT_API
 }

--- a/lintrules-xml/src/main/java/com/chesire/lintrules/xml/XmlLintRegistry.kt
+++ b/lintrules-xml/src/main/java/com/chesire/lintrules/xml/XmlLintRegistry.kt
@@ -16,6 +16,5 @@ class XmlLintRegistry : IssueRegistry() {
             UnexpectedAttribute.issue
         )
 
-    override val api: Int
-        get() = CURRENT_API
+    override val api = CURRENT_API
 }


### PR DESCRIPTION
The API can be set to a value instead of using a getter, so change from `get()=` to just use `=`