### PR TITLE
feat: multiple new line rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ implementation 'com.github.Chesire:LintRules:{version}'
 
 ### lint-gradle
 - **[DuplicateDependency]** - Highlights when the same dependency has been used multiple times within the same Gradle file. 
+- **[MultipleNewline]** - Highlights when multiple blank lines  are detected in a row. 
 - **[MultipleSpaces]** - Highlights when multiple spaces are detected in a row. 
 - **[LexicographicDependencies]** - Highlights when dependencies within a Gradle file are not ordered lexicographically.
 
 ### lint-xml
 - **[ColorCasing]** - Highlights when a color has been defined, but is not all uppercased. 
+- **[MultipleNewline]** - Highlights when multiple blank lines  are detected in a row. 
 - **[MultipleSpaces]** - Highlights when multiple spaces are detected in a row. 
 - **[UnexpectedAttribute]** - Highlights when an attribute has been used in a layout file, but it is not expected on that element.
 

--- a/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
+++ b/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
@@ -15,7 +15,7 @@ import org.w3c.dom.Document
  * which this will call internally.
  */
 abstract class BaseMultipleNewlineDetector : Detector(), GradleScanner, XmlScanner {
-    private val newlineRegex = Regex("(\\r?\\n|\\r)\\s*(\\r?\\n|\\r)\\s*(\\r?\\n|\\r)\\s*")
+    private val newlineRegex = Regex("((\\r?\\n|\\r)\\s*){3}")
     override val customVisitor = true
 
     override fun visitBuildScript(context: Context) {

--- a/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
+++ b/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
@@ -1,0 +1,29 @@
+package com.chesire.lintrules.common.detectors
+
+import com.android.tools.lint.detector.api.Context
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.GradleScanner
+import com.android.tools.lint.detector.api.XmlContext
+import com.android.tools.lint.detector.api.XmlScanner
+import org.w3c.dom.Document
+
+abstract class BaseMultipleNewlineDetector : Detector(), GradleScanner, XmlScanner {
+    override fun visitBuildScript(context: Context) {
+        val contents = context.getContents() ?: return
+        findIssues(contents) { context.report(contents, it) }
+    }
+
+    override fun visitDocument(context: XmlContext, document: Document) {
+        val contents = context.getContents() ?: return
+        findIssues(contents) { context.report(contents, it) }
+    }
+
+    private fun findIssues(contents: CharSequence, onIssueFound: (IntRange) -> Unit) {
+        //
+    }
+
+    /**
+     * Report that an issue has been found in [contents] at [offset].
+     */
+    abstract fun Context.report(contents: CharSequence, offset: IntRange)
+}

--- a/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
+++ b/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
@@ -5,8 +5,15 @@ import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.GradleScanner
 import com.android.tools.lint.detector.api.XmlContext
 import com.android.tools.lint.detector.api.XmlScanner
+import com.chesire.lintrules.common.issues.MultipleNewlineIssue
 import org.w3c.dom.Document
 
+/**
+ * Provides a base class for other [MultipleNewlineIssue] detectors to use.
+ * This base class will do all of the logic required to detect the usage of multiple newlines across
+ * different file types, consumers need to provide an implementation of the [Context.report] method
+ * which this will call internally.
+ */
 abstract class BaseMultipleNewlineDetector : Detector(), GradleScanner, XmlScanner {
     override fun visitBuildScript(context: Context) {
         val contents = context.getContents() ?: return

--- a/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
+++ b/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
@@ -15,6 +15,9 @@ import org.w3c.dom.Document
  * which this will call internally.
  */
 abstract class BaseMultipleNewlineDetector : Detector(), GradleScanner, XmlScanner {
+    private val newlineRegex = Regex("(\\r?\\n|\\r)\\s*(\\r?\\n|\\r)\\s*(\\r?\\n|\\r)\\s*")
+    override val customVisitor = true
+
     override fun visitBuildScript(context: Context) {
         val contents = context.getContents() ?: return
         findIssues(contents) { context.report(contents, it) }
@@ -26,7 +29,9 @@ abstract class BaseMultipleNewlineDetector : Detector(), GradleScanner, XmlScann
     }
 
     private fun findIssues(contents: CharSequence, onIssueFound: (IntRange) -> Unit) {
-        //
+        newlineRegex.findAll(contents).forEach {
+            onIssueFound(IntRange(it.range.first.inc(), it.range.last.inc()))
+        }
     }
 
     /**

--- a/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
+++ b/lintrules-common/src/main/java/com/chesire/lintrules/common/detectors/BaseMultipleNewlineDetector.kt
@@ -15,7 +15,7 @@ import org.w3c.dom.Document
  * which this will call internally.
  */
 abstract class BaseMultipleNewlineDetector : Detector(), GradleScanner, XmlScanner {
-    private val newlineRegex = Regex("((\\r?\\n|\\r)\\s*){3}")
+    private val newlineRegex = Regex("((\\r?\\n|\\r)\\s*){3,}")
     override val customVisitor = true
 
     override fun visitBuildScript(context: Context) {

--- a/lintrules-common/src/main/java/com/chesire/lintrules/common/issues/MultipleNewlineIssue.kt
+++ b/lintrules-common/src/main/java/com/chesire/lintrules/common/issues/MultipleNewlineIssue.kt
@@ -1,0 +1,25 @@
+package com.chesire.lintrules.common.issues
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.Severity
+
+/**
+ * [Issue] for when there are multiple newlines in a file.
+ */
+interface MultipleNewlineIssue : LintIssue {
+    override val id: String
+        get() = "MultipleNewline"
+    override val briefDescription: String
+        get() = "Detected the use of more than one newline character"
+    override val explanation: String
+        get() = "Stylistic choice to remove duplicated newlines"
+    override val category: Category
+        get() = Category.CORRECTNESS
+    override val priority: Int
+        get() = 1
+    override val severity: Severity
+        get() = Severity.WARNING
+    override val message: String
+        get() = "Only a single empty line should be used."
+}

--- a/lintrules-common/src/main/java/com/chesire/lintrules/common/issues/MultipleNewlineIssue.kt
+++ b/lintrules-common/src/main/java/com/chesire/lintrules/common/issues/MultipleNewlineIssue.kt
@@ -11,9 +11,9 @@ interface MultipleNewlineIssue : LintIssue {
     override val id: String
         get() = "MultipleNewline"
     override val briefDescription: String
-        get() = "Detected the use of more than one newline character"
+        get() = "Detected the use of more than one empty line"
     override val explanation: String
-        get() = "Stylistic choice to remove duplicated newlines"
+        get() = "Stylistic choice to remove duplicated empty lines"
     override val category: Category
         get() = Category.CORRECTNESS
     override val priority: Int

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/GradleLintRegistry.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/GradleLintRegistry.kt
@@ -5,6 +5,7 @@ import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import com.chesire.lintrules.gradle.issues.DuplicateDependency
 import com.chesire.lintrules.gradle.issues.LexicographicDependencies
+import com.chesire.lintrules.gradle.issues.MultipleNewline
 import com.chesire.lintrules.gradle.issues.MultipleSpace
 
 /**
@@ -15,6 +16,7 @@ class GradleLintRegistry : IssueRegistry() {
         get() = listOf(
             DuplicateDependency.issue,
             LexicographicDependencies.issue,
+            MultipleNewline.issue,
             MultipleSpace.issue
         )
 

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/MultipleNewlineDetector.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/MultipleNewlineDetector.kt
@@ -1,0 +1,24 @@
+package com.chesire.lintrules.gradle.detectors
+
+import com.android.tools.lint.detector.api.Context
+import com.android.tools.lint.detector.api.Location
+import com.chesire.lintrules.gradle.issues.MultipleNewline
+
+/**
+ * Gradle detector for the [BaseMultipleNewlineDetector].
+ */
+class MultipleNewlineDetector : BaseMultipleNewlineDetector() {
+    override fun Context.report(contents: CharSequence, offset: IntRange) {
+        report(
+            MultipleNewline.issue,
+            Location.create(
+                file,
+                contents,
+                offset.first,
+                offset.last
+            ),
+            MultipleNewline.message,
+            null
+        )
+    }
+}

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/MultipleNewlineDetector.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/MultipleNewlineDetector.kt
@@ -2,6 +2,7 @@ package com.chesire.lintrules.gradle.detectors
 
 import com.android.tools.lint.detector.api.Context
 import com.android.tools.lint.detector.api.Location
+import com.chesire.lintrules.common.detectors.BaseMultipleNewlineDetector
 import com.chesire.lintrules.gradle.issues.MultipleNewline
 
 /**

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/issues/MultipleNewline.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/issues/MultipleNewline.kt
@@ -1,0 +1,21 @@
+package com.chesire.lintrules.gradle.issues
+
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.Scope
+import com.chesire.lintrules.gradle.detectors.MultipleNewlineDetector
+
+/**
+ * [Issue] for when there are multiple new line characters together.
+ */
+object MultipleNewline : MultipleNewlineIssue {
+    override val issue = Issue.create(
+        id,
+        briefDescription,
+        explanation,
+        category,
+        priority,
+        severity,
+        Implementation(MultipleNewlineDetector::class.java, Scope.GRADLE_SCOPE)
+    )
+}

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/issues/MultipleNewline.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/issues/MultipleNewline.kt
@@ -3,6 +3,7 @@ package com.chesire.lintrules.gradle.issues
 import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.Scope
+import com.chesire.lintrules.common.issues.MultipleNewlineIssue
 import com.chesire.lintrules.gradle.detectors.MultipleNewlineDetector
 
 /**

--- a/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/GradleLintRegistryTests.kt
+++ b/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/GradleLintRegistryTests.kt
@@ -3,6 +3,7 @@ package com.chesire.lintrules.gradle
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.chesire.lintrules.gradle.issues.DuplicateDependency
 import com.chesire.lintrules.gradle.issues.LexicographicDependencies
+import com.chesire.lintrules.gradle.issues.MultipleNewline
 import com.chesire.lintrules.gradle.issues.MultipleSpace
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -14,6 +15,7 @@ class GradleLintRegistryTests {
         val registry = GradleLintRegistry()
         assertTrue(registry.issues.contains(DuplicateDependency.issue))
         assertTrue(registry.issues.contains(LexicographicDependencies.issue))
+        assertTrue(registry.issues.contains(MultipleNewline.issue))
         assertTrue(registry.issues.contains(MultipleSpace.issue))
     }
 

--- a/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/MultipleNewlineDetectorTests.kt
+++ b/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/MultipleNewlineDetectorTests.kt
@@ -1,0 +1,98 @@
+package com.chesire.lintrules.gradle.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.gradle
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.chesire.lintrules.gradle.issues.MultipleNewline
+import org.junit.Test
+
+class MultipleNewlineDetectorTests {
+
+    @Test
+    fun `multipleNewlines should be no issue with valid Gradle file`() {
+        lint()
+            .allowMissingSdk()
+            .files(
+                gradle(
+                    """
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+dependencies {
+    implementation project(path: ":lintrules-common")
+
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:0.0.0"
+
+    compileOnly "com.android.tools.lint:lint-api:0.0.0"
+    compileOnly "com.android.tools.lint:lint-checks:0.0.0"
+
+    testImplementation "com.android.tools.lint:lint:0.0.0"
+    testImplementation "com.android.tools.lint:lint-tests:0.0.0"
+}
+
+jar {
+    manifest {
+        attributes('Lint-Registry-v2': 'com.chesire.lintrules.gradle.GradleLintRegistry')
+    }
+}
+                """.trimIndent()
+                ).indented()
+            )
+            .issues(MultipleNewline.issue)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `multipleNewlines should flag issues in invalid Gradle file`() {
+        lint()
+            .allowMissingSdk()
+            .files(
+                gradle(
+                    """
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+
+dependencies {
+    implementation project(path: ":lintrules-common")
+
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:0.0.0"
+
+    compileOnly "com.android.tools.lint:lint-api:0.0.0"
+    compileOnly "com.android.tools.lint:lint-checks:0.0.0"
+    
+
+    testImplementation "com.android.tools.lint:lint:0.0.0"
+    testImplementation "com.android.tools.lint:lint-tests:0.0.0"
+}
+
+jar {
+
+
+    manifest  {
+        attributes('Lint-Registry-v2': 'com.chesire.lintrules.gradle.GradleLintRegistry')
+    }
+}
+                """.trimIndent()
+                ).indented()
+            )
+            .issues(MultipleNewline.issue)
+            .run()
+            .expect(
+                """
+                |build.gradle:1: Warning: Multiple spaces should not be used. [MultipleSpace]
+                |apply  plugin: 'java-library'
+                |     ~~
+                |build.gradle:5: Warning: Multiple spaces should not be used. [MultipleSpace]
+                |    implementation project(path:  ":lintrules-common")
+                |                                ~~
+                |build.gradle:9: Warning: Multiple spaces should not be used. [MultipleSpace]
+                |    compileOnly  "com.android.tools.lint:lint-api:0.0.0"
+                |               ~~
+                |build.gradle:17: Warning: Multiple spaces should not be used. [MultipleSpace]
+                |    manifest  {
+                |            ~~
+                |0 errors, 4 warnings""".trimMargin()
+            )
+    }
+}

--- a/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/MultipleNewlineDetectorTests.kt
+++ b/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/MultipleNewlineDetectorTests.kt
@@ -80,19 +80,16 @@ jar {
             .run()
             .expect(
                 """
-                |build.gradle:1: Warning: Multiple spaces should not be used. [MultipleSpace]
-                |apply  plugin: 'java-library'
-                |     ~~
-                |build.gradle:5: Warning: Multiple spaces should not be used. [MultipleSpace]
-                |    implementation project(path:  ":lintrules-common")
-                |                                ~~
-                |build.gradle:9: Warning: Multiple spaces should not be used. [MultipleSpace]
-                |    compileOnly  "com.android.tools.lint:lint-api:0.0.0"
-                |               ~~
-                |build.gradle:17: Warning: Multiple spaces should not be used. [MultipleSpace]
-                |    manifest  {
-                |            ~~
-                |0 errors, 4 warnings""".trimMargin()
+                |build.gradle:3: Warning: Only a single empty line should be used. [MultipleNewline]
+                |
+                |^
+                |build.gradle:12: Warning: Only a single empty line should be used. [MultipleNewline]
+                |    
+                |^
+                |build.gradle:19: Warning: Only a single empty line should be used. [MultipleNewline]
+                |
+                |^
+                |0 errors, 3 warnings""".trimMargin()
             )
     }
 }

--- a/lintrules-xml/src/main/java/com/chesire/lintrules/xml/XmlLintRegistry.kt
+++ b/lintrules-xml/src/main/java/com/chesire/lintrules/xml/XmlLintRegistry.kt
@@ -4,6 +4,7 @@ import com.android.tools.lint.client.api.IssueRegistry
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import com.chesire.lintrules.xml.issues.ColorCasing
+import com.chesire.lintrules.xml.issues.MultipleNewline
 import com.chesire.lintrules.xml.issues.MultipleSpace
 import com.chesire.lintrules.xml.issues.UnexpectedAttribute
 
@@ -14,6 +15,7 @@ class XmlLintRegistry : IssueRegistry() {
     override val issues: List<Issue>
         get() = listOf(
             ColorCasing.issue,
+            MultipleNewline.issue,
             MultipleSpace.issue,
             UnexpectedAttribute.issue
         )

--- a/lintrules-xml/src/main/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetector.kt
+++ b/lintrules-xml/src/main/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetector.kt
@@ -1,0 +1,25 @@
+package com.chesire.lintrules.xml.detectors
+
+import com.android.tools.lint.detector.api.Context
+import com.android.tools.lint.detector.api.Location
+import com.chesire.lintrules.common.detectors.BaseMultipleNewlineDetector
+import com.chesire.lintrules.xml.issues.MultipleNewline
+
+/**
+ * XML detector for the [BaseMultipleNewlineDetector].
+ */
+class MultipleNewlineDetector : BaseMultipleNewlineDetector() {
+    override fun Context.report(contents: CharSequence, offset: IntRange) {
+        report(
+            MultipleNewline.issue,
+            Location.create(
+                file,
+                contents,
+                offset.first,
+                offset.last
+            ),
+            MultipleNewline.message,
+            null
+        )
+    }
+}

--- a/lintrules-xml/src/main/java/com/chesire/lintrules/xml/issues/MultipleNewline.kt
+++ b/lintrules-xml/src/main/java/com/chesire/lintrules/xml/issues/MultipleNewline.kt
@@ -1,0 +1,26 @@
+package com.chesire.lintrules.xml.issues
+
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.Scope
+import com.chesire.lintrules.common.issues.MultipleNewlineIssue
+import com.chesire.lintrules.xml.detectors.MultipleNewlineDetector
+
+/**
+ * [Issue] for when there are multiple new line characters together.
+ */
+object MultipleNewline : MultipleNewlineIssue {
+    override val issue = Issue.create(
+        id,
+        briefDescription,
+        explanation,
+        category,
+        priority,
+        severity,
+        Implementation(
+            MultipleNewlineDetector::class.java,
+            Scope.ALL_RESOURCES_SCOPE,
+            Scope.MANIFEST_SCOPE
+        )
+    )
+}

--- a/lintrules-xml/src/test/java/com/chesire/lintrules/xml/XmlLintRegistryTests.kt
+++ b/lintrules-xml/src/test/java/com/chesire/lintrules/xml/XmlLintRegistryTests.kt
@@ -2,6 +2,7 @@ package com.chesire.lintrules.xml
 
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.chesire.lintrules.xml.issues.ColorCasing
+import com.chesire.lintrules.xml.issues.MultipleNewline
 import com.chesire.lintrules.xml.issues.MultipleSpace
 import com.chesire.lintrules.xml.issues.UnexpectedAttribute
 import org.junit.Assert.assertEquals
@@ -13,6 +14,7 @@ class XmlLintRegistryTests {
     fun `issues returns expected list`() {
         val registry = XmlLintRegistry()
         assertTrue(registry.issues.contains(ColorCasing.issue))
+        assertTrue(registry.issues.contains(MultipleNewline.issue))
         assertTrue(registry.issues.contains(MultipleSpace.issue))
         assertTrue(registry.issues.contains(UnexpectedAttribute.issue))
     }

--- a/lintrules-xml/src/test/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetectorTests.kt
+++ b/lintrules-xml/src/test/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetectorTests.kt
@@ -87,16 +87,13 @@ class MultipleNewlineDetectorTests {
             .run()
             .expect(
                 """
-                |res/layout/layout_file.xml:1: Warning: Multiple spaces should not be used. [MultipleSpace]
-                |<?xml version="1.0"  encoding="utf-8"?>
-                |                   ~~
-                |res/layout/layout_file.xml:2: Warning: Multiple spaces should not be used. [MultipleSpace]
-                |<ScrollView  xmlns:android="http://schemas.android.com/apk/res/android"
-                |           ~~
-                |res/layout/layout_file.xml:21: Warning: Multiple spaces should not be used. [MultipleSpace]
-                |            app:layout_constraintTop_toTopOf="parent"  />
-                |                                                     ~~
-                |0 errors, 3 warnings""".trimMargin()
+                |res/layout/layout_file.xml:7: Warning: Only a single empty line should be used. [MultipleNewline]
+                |
+                |^
+                |res/layout/layout_file.xml:24: Warning: Only a single empty line should be used. [MultipleNewline]
+                |    
+                |^
+                |0 errors, 2 warnings""".trimMargin()
             )
     }
 }

--- a/lintrules-xml/src/test/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetectorTests.kt
+++ b/lintrules-xml/src/test/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetectorTests.kt
@@ -87,7 +87,7 @@ class MultipleNewlineDetectorTests {
             .run()
             .expect(
                 """
-                |res/layout/layout_file.xml:7: Warning: Only a single empty line should be used. [MultipleNewline]
+                |res/layout/layout_file.xml:14: Warning: Only a single empty line should be used. [MultipleNewline]
                 |
                 |^
                 |res/layout/layout_file.xml:24: Warning: Only a single empty line should be used. [MultipleNewline]

--- a/lintrules-xml/src/test/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetectorTests.kt
+++ b/lintrules-xml/src/test/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetectorTests.kt
@@ -61,13 +61,13 @@ class MultipleNewlineDetectorTests {
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:focusableInTouchMode="true"
         android:gravity="center_horizontal"
         android:orientation="vertical">
+
 
         <ImageView
             android:id="@+id/headerImage"

--- a/lintrules-xml/src/test/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetectorTests.kt
+++ b/lintrules-xml/src/test/java/com/chesire/lintrules/xml/detectors/MultipleNewlineDetectorTests.kt
@@ -1,0 +1,102 @@
+package com.chesire.lintrules.xml.detectors
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.xml
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.chesire.lintrules.xml.issues.MultipleNewline
+import org.junit.Test
+
+class MultipleNewlineDetectorTests {
+
+    @Test
+    fun `multipleNewline should be no issue with valid XML file`() {
+        lint()
+            .allowMissingSdk()
+            .files(
+                xml(
+                    "res/layout/layout_file.xml",
+                    """
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:focusableInTouchMode="true"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/headerImage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </LinearLayout>
+</ScrollView>
+                """.trimIndent()
+                ).indented()
+            )
+            .issues(MultipleNewline.issue)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `multipleNewline should flag issues in invalid XML file`() {
+        lint()
+            .allowMissingSdk()
+            .files(
+                xml(
+                    "res/layout/layout_file.xml",
+                    """
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:focusableInTouchMode="true"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/headerImage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </LinearLayout>
+    
+    
+</ScrollView>
+                """.trimIndent()
+                ).indented()
+            )
+            .issues(MultipleNewline.issue)
+            .run()
+            .expect(
+                """
+                |res/layout/layout_file.xml:1: Warning: Multiple spaces should not be used. [MultipleSpace]
+                |<?xml version="1.0"  encoding="utf-8"?>
+                |                   ~~
+                |res/layout/layout_file.xml:2: Warning: Multiple spaces should not be used. [MultipleSpace]
+                |<ScrollView  xmlns:android="http://schemas.android.com/apk/res/android"
+                |           ~~
+                |res/layout/layout_file.xml:21: Warning: Multiple spaces should not be used. [MultipleSpace]
+                |            app:layout_constraintTop_toTopOf="parent"  />
+                |                                                     ~~
+                |0 errors, 3 warnings""".trimMargin()
+            )
+    }
+}


### PR DESCRIPTION
Add a new rule that will detect when multiple blank lines are used in a row. This is primarily a stylistic choice to only use only a single blank line between sections.

Closes #61 