### PR TITLE
fix: duplicate dependency on a nested project would fail check

### DIFF
--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/Dependency.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/Dependency.kt
@@ -11,11 +11,32 @@ data class Dependency(
      */
     val type: String,
     /**
+     * The domain of the dependency.
+     *
+     * Ex: project or "".
+     */
+    val domain: String,
+    /**
      * Name of the dependency.
      */
     val name: String,
     /**
      * Version of the dependency.
      */
-    val version: String
-)
+    val version: String,
+    /**
+     * Full value provided of the [name] & [version].
+     */
+    val value: String
+) {
+    /**
+     * Checks if [other] is the same dependency as this one.
+     */
+    fun sameAs(other: Dependency): Boolean {
+        return if (domain.isNotBlank()) {
+            domain == other.domain && type == other.type && value == other.value
+        } else {
+            type == other.type && name == other.name
+        }
+    }
+}

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/DependencyParser.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/DependencyParser.kt
@@ -14,10 +14,11 @@ object DependencyParser {
             value.indexOf(encasingChar) + 1,
             value.lastIndexOf(encasingChar)
         )
+        val dependencyDomain = getDependencyDomain(value)
         val dependencyName = getDependencyName(dependencyItem)
-        val dependencyVersion = dependencyItem.substring(dependencyItem.lastIndexOf(':') + 1)
+        val dependencyVersion = getDependencyVersion(dependencyItem)
 
-        return Dependency(type, dependencyName, dependencyVersion)
+        return Dependency(type, dependencyDomain, dependencyName, dependencyVersion, dependencyItem)
     }
 
     private fun getEncasingChar(value: String): Char? = when {
@@ -26,9 +27,13 @@ object DependencyParser {
         else -> null
     }
 
+    private fun getDependencyDomain(value: String) = value.takeWhile { it.isLetterOrDigit() }
+
     private fun getDependencyName(value: String) =
         value
             .substring(0, value.lastIndexOf(':'))
             .takeIf { it.isNotEmpty() }
             ?: value
+
+    private fun getDependencyVersion(value: String) = value.substring(value.lastIndexOf(':') + 1)
 }

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetector.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetector.kt
@@ -15,7 +15,7 @@ class DuplicateDependencyDetector : Detector(), GradleScanner {
         private const val PARENT_TAG = "dependencies"
     }
 
-    private val dependencyItems = mutableListOf<Pair<String, String>>()
+    private val dependencyItems = mutableListOf<Dependency>()
 
     override fun checkDslPropertyAssignment(
         context: GradleContext,
@@ -32,7 +32,7 @@ class DuplicateDependencyDetector : Detector(), GradleScanner {
         }
         DependencyParser.parseDependency(property, value)?.let { dependency ->
             reportIfDuplicate(context, dependency, valueCookie)
-            dependencyItems.add(dependency.type to dependency.name)
+            dependencyItems.add(dependency)
         }
     }
 
@@ -41,7 +41,7 @@ class DuplicateDependencyDetector : Detector(), GradleScanner {
         dependency: Dependency,
         valueCookie: Any
     ) {
-        if (dependencyItems.any { it.first == dependency.type && it.second == dependency.name }) {
+        if (isDuplicate(dependency)) {
             context.report(
                 DuplicateDependency.issue,
                 context.getLocation(valueCookie),
@@ -49,4 +49,6 @@ class DuplicateDependencyDetector : Detector(), GradleScanner {
             )
         }
     }
+
+    private fun isDuplicate(dependency: Dependency) = dependencyItems.any { it.sameAs(dependency) }
 }

--- a/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetectorTests.kt
+++ b/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/DuplicateDependencyDetectorTests.kt
@@ -309,4 +309,40 @@ dependencies {
                 |0 errors, 1 warnings""".trimMargin()
             )
     }
+
+    @Test
+    fun `duplicateDependency should not be an issue with different nested projects`() {
+        TestLintTask
+            .lint()
+            .allowMissingSdk()
+            .files(
+                TestFiles.gradle(
+                    """
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    
+    implementation project(path: ':features:core')
+    implementation project(path: ':features:database')
+    implementation project(path: ':server')
+        
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core-ktx:1.1.0'
+    
+    testImplementation project(path: ':testutils')
+    testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
+    testImplementation "junit:junit:4.12"
+    
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    
+    lintChecks project(":lintrules")
+}
+                    """.trimIndent()
+                ).indented()
+            )
+            .issues(DuplicateDependency.issue)
+            .run()
+            .expectClean()
+    }
 }


### PR DESCRIPTION
Projects that were added to the project via `implementation project(path: ":features:discover")`
would fail to be correctly checked as a duplicate dependency and would alwys be flagged as true, due
to the parsing only checking the first part of the path and not the whole thing. Update the
Dependency model to have a method to check which is a bit smarter. As part of this cleaned up some
of the logic in a few areas.

Closes #88