### PR TITLE
fix: dependency ordering being incorrect when using nested projects

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,9 +1,24 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">
+      <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/Domain.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/Domain.kt
@@ -1,0 +1,10 @@
+package com.chesire.lintrules.gradle
+
+/**
+ * Different domains a dependency can exist in.
+ * [value] references the value the dependency has.
+ */
+enum class Domain(val value: String) {
+    None(""),
+    Project("project")
+}

--- a/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetectorTests.kt
+++ b/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetectorTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package com.chesire.lintrules.gradle.detectors
 
 import com.android.tools.lint.checks.infrastructure.TestFiles
@@ -79,6 +81,27 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     
     lintChecks project(":lintrules")
+}
+                    """.trimIndent()
+                ).indented()
+            )
+            .issues(LexicographicDependencies.issue)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `lexicographicOrder should be no issue with nested project dependencies`() {
+        TestLintTask
+            .lint()
+            .allowMissingSdk()
+            .files(
+                TestFiles.gradle(
+                    """
+dependencies {
+    implementation project(":libraries:kitsu:trending")
+    implementation project(":libraries:kitsu:user")
+    implementation project(":libraries:library")
 }
                     """.trimIndent()
                 ).indented()


### PR DESCRIPTION
Nested projects such as server:kitsu:auth would not be correctly checked for their ordering. Make
some updates so depending on the domain of the dependency it can have different rules