### PR TITLE
chore: remove the kotlin version in each gradle file

### DIFF
--- a/lintrules-common/build.gradle
+++ b/lintrules-common/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
     compileOnly "com.android.tools.lint:lint-api:$lintVersion"
     compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
 }

--- a/lintrules-gradle/build.gradle
+++ b/lintrules-gradle/build.gradle
@@ -13,8 +13,6 @@ sourceSets {
 }
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
     compileOnly "com.android.tools.lint:lint-api:$lintVersion"
     compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
 

--- a/lintrules-xml/build.gradle
+++ b/lintrules-xml/build.gradle
@@ -13,8 +13,6 @@ sourceSets {
 }
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
     compileOnly "com.android.tools.lint:lint-api:$lintVersion"
     compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
 


### PR DESCRIPTION
This is automatically added now, so there is no need to be explicit in each gradle file