### PR TITLE
refactor: remove the ordering exclusion for the kotlin version

### DIFF
--- a/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetector.kt
+++ b/lintrules-gradle/src/main/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetector.kt
@@ -38,8 +38,7 @@ class LexicographicDependenciesDetector : Detector(), GradleScanner {
     }
 
     // Certain items should not be included when checking
-    private fun isValidItem(value: String) =
-        !(value.contains("org.jetbrains.kotlin:kotlin-stdlib") || value.contains("fileTree"))
+    private fun isValidItem(value: String) = !value.contains("fileTree")
 
     private fun reportIfNotLexicographicOrder(
         context: GradleContext,

--- a/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetectorTests.kt
+++ b/lintrules-gradle/src/test/java/com/chesire/lintrules/gradle/detectors/LexicographicDependenciesDetectorTests.kt
@@ -38,9 +38,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     
     testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
     testImplementation 'junit:junit:4.12'
@@ -68,9 +68,9 @@ dependencies {
                     """
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     
     testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
     testImplementation 'junit:junit:4.12'
@@ -98,9 +98,9 @@ dependencies {
                     """
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.1.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     implementation 'z.zandroid.ztools.zlint:lint-tests:26.5.1'
     
     testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
@@ -129,9 +129,46 @@ dependencies {
                     """
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
+    
+    testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
+    testImplementation 'junit:junit:4.12'
+    
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    
+    lintChecks project(":lintrules")
+}
+                    """.trimIndent()
+                ).indented()
+            )
+            .issues(LexicographicDependencies.issue)
+            .run()
+            .expect(
+                """
+                |build.gradle:4: Warning: Dependencies should be listed in lexicographic order. [LexicographicDependencies]
+                |    implementation 'androidx.appcompat:appcompat:1.1.0'
+                |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                |0 errors, 1 warnings""".trimMargin()
+            )
+    }
+
+    @Test
+    fun `lexicographicOrder should be an issue with invalid lexicographic order same owner`() {
+        TestLintTask
+            .lint()
+            .allowMissingSdk()
+            .files(
+                TestFiles.gradle(
+                    """
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.chesire.lintrules:lint-gradle:1.1.1'
+    implementation 'com.chesire.lintrules:lint-xml:1.1.1'
+    implementation 'com.chesire:lifecyklelog:2.1.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
     
     testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
     testImplementation 'junit:junit:4.12'
@@ -149,43 +186,6 @@ dependencies {
             .expect(
                 """
                 |build.gradle:5: Warning: Dependencies should be listed in lexicographic order. [LexicographicDependencies]
-                |    implementation 'androidx.appcompat:appcompat:1.1.0'
-                |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                |0 errors, 1 warnings""".trimMargin()
-            )
-    }
-
-    @Test
-    fun `lexicographicOrder should be an issue with invalid lexicographic order same owner`() {
-        TestLintTask
-            .lint()
-            .allowMissingSdk()
-            .files(
-                TestFiles.gradle(
-                    """
-dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
-    implementation 'com.chesire.lintrules:lint-gradle:1.1.1'
-    implementation 'com.chesire.lintrules:lint-xml:1.1.1'
-    implementation 'com.chesire:lifecyklelog:2.1.0'
-    
-    testImplementation 'com.android.tools.lint:lint-tests:26.5.1'
-    testImplementation 'junit:junit:4.12'
-    
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    
-    lintChecks project(":lintrules")
-}
-                    """.trimIndent()
-                ).indented()
-            )
-            .issues(LexicographicDependencies.issue)
-            .run()
-            .expect(
-                """
-                |build.gradle:6: Warning: Dependencies should be listed in lexicographic order. [LexicographicDependencies]
                 |    implementation 'com.chesire:lifecyklelog:2.1.0'
                 |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 |0 errors, 1 warnings""".trimMargin()


### PR DESCRIPTION
Remove the exclusion as this dependency is no longer required to be added, and if it is it should be
ordered correctly