### PR TITLE
fix: compilation issue with all projects lintPublish

### DIFF
--- a/lintrules-common/build.gradle
+++ b/lintrules-common/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
 dependencies {
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
     compileOnly "com.android.tools.lint:lint-api:$lintVersion"
     compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
 }

--- a/lintrules-gradle/build.gradle
+++ b/lintrules-gradle/build.gradle
@@ -13,6 +13,8 @@ sourceSets {
 }
 
 dependencies {
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
     compileOnly "com.android.tools.lint:lint-api:$lintVersion"
     compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
 

--- a/lintrules-xml/build.gradle
+++ b/lintrules-xml/build.gradle
@@ -13,6 +13,8 @@ sourceSets {
 }
 
 dependencies {
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
     compileOnly "com.android.tools.lint:lint-api:$lintVersion"
     compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
 


### PR DESCRIPTION
Revert "chore: remove the kotlin version in each gradle file (#134)"
This reverts commit 2dec69890d3e42158ebde8eef7283c661c50d7d1.

It looks like the Kotlin version is required to be `compileOnly` or the default configuration does implementation, which causes some issues with assembling modules which contain lintPublish.